### PR TITLE
添加对Rest类解析，兼容有些采用Rest作为Controller类结尾的项目

### DIFF
--- a/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/DefaultSmallDocletImpl.java
+++ b/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/DefaultSmallDocletImpl.java
@@ -46,7 +46,7 @@ public class DefaultSmallDocletImpl extends SmallDoclet {
     private void handleClassDocs(RootDoc root) {
         ClassDoc[] classes = root.classes();
         for (ClassDoc classDoc : classes) {
-            if (!classDoc.name().endsWith(Constants.CONTROLLER))//只解析*Controller类
+            if (!classDoc.name().endsWith(Constants.CONTROLLER) && !classDoc.name().endsWith(Constants.REST))//解析*Controller类和Rest类
                 continue;
             handleClassDoc(classDoc);
         }

--- a/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/constant/Constants.java
+++ b/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/constant/Constants.java
@@ -11,4 +11,5 @@ public class Constants {
 
     public static final String CONTROLLER = "Controller";
 
+    public static final String REST = "Rest";
 }


### PR DESCRIPTION
我们的项目中有些包里面是采用Rest为类结尾的，所以需要兼容一下。