### PR TITLE
兼容一下处理方法中碰到异常的情况，目前的处理方案是直接删除。

### DIFF
--- a/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/DefaultSmallDocletImpl.java
+++ b/smalldoc-core/src/main/java/com/github/liuhuagui/smalldoc/core/DefaultSmallDocletImpl.java
@@ -10,6 +10,8 @@ import com.github.liuhuagui.smalldoc.util.Assert;
 import com.github.liuhuagui.smalldoc.util.TypeUtils;
 import com.github.liuhuagui.smalldoc.util.Utils;
 import com.sun.javadoc.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 
@@ -21,6 +23,7 @@ import java.util.ArrayList;
  * @author KaiKang
  */
 public class DefaultSmallDocletImpl extends SmallDoclet {
+    private static final Logger log = LoggerFactory.getLogger(DefaultSmallDocletImpl.class);
 
     public DefaultSmallDocletImpl(SmallDocContext smallDocContext) {
         super(smallDocContext);
@@ -94,9 +97,14 @@ public class DefaultSmallDocletImpl extends SmallDoclet {
     private JSONArray getMehodDocsInfo(ClassDoc classDoc, JSONObject classMappingInfo) {
         JSONArray methodsJSONArray = new JSONArray();
         for (MethodDoc methodDoc : classDoc.methods()) {
-            if (!methodDoc.isPublic())
-                continue;
-            handleMethodDoc(methodDoc, methodsJSONArray, classMappingInfo);
+            try {
+                if (!methodDoc.isPublic())
+                    continue;
+                handleMethodDoc(methodDoc, methodsJSONArray, classMappingInfo);
+            } catch (Exception e) {
+                log.error("处理方法异常, 从列表删除，请检查接口文档！", e);
+                methodsJSONArray.remove(methodsJSONArray.size()-1);
+            }
         }
         return methodsJSONArray;
     }


### PR DESCRIPTION
目前在解析方法过程中碰到异常时没有处理，会直接中断后面所有的Controller及其他方法的解析。
修改为在解析方法处理时处理异常，方式是从列表中直接删除该方法。这样界面上就不会显示这个接口了，所以使用者需要注意日志里的此类错误信息:  处理方法异常, 从列表删除，请检查接口文档!